### PR TITLE
Lowercases pwd reference when setting current directory

### DIFF
--- a/src/parse.sh
+++ b/src/parse.sh
@@ -2,7 +2,7 @@
 
 # SET DEFAULT VALUES
 RESET=1
-DIRECTORY=$(PWD)
+DIRECTORY=$(pwd)
 SEARCH="./*"
 OUTPUT="/dev/null"
 


### PR DESCRIPTION
Fixes casing issue I'm experiencing.